### PR TITLE
DM-20839: Switch to an absolute link to edition switcher (version 0.2.2)

### DIFF
--- a/lsst_dd_rtd_theme/layout.html
+++ b/lsst_dd_rtd_theme/layout.html
@@ -94,7 +94,7 @@
 
           <ul class="edition-switcher">
             <li>Edition: {{ version }}</li>
-            <li><a href="../v">Switch editions</a></li>
+            <li><a href="/v">Switch editions</a></li>
             {% if edit_url %}
             <li><a href="{{ edit_url }}">Edit on GitHub</a></li>
             {% endif %}


### PR DESCRIPTION
We think that the newish Fastly redirect rules for LTD should let this work now.